### PR TITLE
Skip ##HL (Channel Hierarchy) blocks during data block parsing

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -893,7 +893,10 @@ impl MdfIndex {
                     // Move to the next DLBLOCK in the chain (0 = end)
                     current_block_address = data_list_block.next_dl_addr;
                 }
-
+                "##HL" => {
+                    current_block_address = 0;
+                    continue;
+                }
                 unexpected_id => {
                     return Err(Error::BlockIDError {
                         actual: unexpected_id.to_string(),
@@ -1199,6 +1202,9 @@ impl MdfIndex {
 
                     // Follow the chain
                     next_addr = dl_block.next_dl_addr;
+                }
+                "##HL" => {
+                    break;
                 }
                 other => {
                     return Err(Error::BlockIDError {

--- a/src/parsing/raw_data_group.rs
+++ b/src/parsing/raw_data_group.rs
@@ -129,7 +129,9 @@ impl RawDataGroup {
                     // Move to the next DLBLOCK in the chain (0 = end)
                     current_block_address = data_list_block.next_dl_addr;
                 }
-
+                "##HL" => {
+                    continue;
+                }
                 unexpected_id => {
                     return Err(Error::BlockIDError {
                         actual: unexpected_id.to_string(),
@@ -243,6 +245,9 @@ impl RawDataGroup {
                     }
 
                     current_block_address = data_list_block.next_dl_addr;
+                }
+                "##HL" => {
+                    continue;
                 }
                 unexpected_id => {
                     return Err(Error::BlockIDError {


### PR DESCRIPTION
Some MDF4 files contain ##HL (Channel Hierarchy) blocks which define channel dependencies. These blocks appear in the data block chain but don't contain actual sample data (in my example created by tools like Canape).

This patch just skips over these blocks without doing anything useful, but allows parsing the files.